### PR TITLE
add index.html, start on ollama api in js

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="">
+    <head>
+        <meta charset="utf-8" />
+        <title></title>
+        <script src="/serviceScript.js"></script>
+    </head>
+    <body>
+        <header></header>
+        <main>
+            <div>
+                <h1>QuestionGenie</h1>
+                <form action="javascript:search()">
+                    <input
+                        type="text"
+                        id="user-search"
+                        name="user-search"
+                        placeholder="Enter Query..."
+                    />
+                    <input type="submit" value="Submit" />
+                </form>
+                <p id="ai-status"></p>
+                <div id="ai-response">
+                    <h3>Explanation</h3>
+                    <p id="explanation"></p>
+                    <h3>Example Problem</h3>
+                    <div id="exampleProblem">
+                        <p id="exampleQuestion"></p>
+                        <p id="exampleChoiceA"></p>
+                        <p id="exampleChoiceB"></p>
+                        <p id="exampleChoiceC"></p>
+                        <p id="exampleChoiceD"></p>
+                        <p id="exampleAnswer"></p>
+                    </div>
+                    <h3>Example Explanation</h3>
+                    <p id="exampleExplanation"></p>
+                </div>
+            </div>
+        </main>
+        <footer></footer>
+    </body>
+</html>

--- a/serviceScript.js
+++ b/serviceScript.js
@@ -1,51 +1,199 @@
 //EDITION ONE CODE
 
+// CONFIG: put this in another file or something?
+const OLLAMA_HOST = "http://127.0.0.1:11434";
+const OLLAMA_MODEL = "llama3:latest";
+const OLLAMA_SYSTEM_PROMPT = `
+  You are QuestionGenie, a tool that generates practice problems and explanations for students.
+
+  You must provide all responses in JSON format.
+
+  There are two types of requests you can make to the API: explanations and problems.
+
+  When generating a "problem", the following fields are required:
+  - question: a string representing the question to ask the user
+  - choices: an array of 4 strings representing the choices for the user to select from
+  - answer: an integer representing the index of the correct answer in the choices array
+
+  When generating an "explanation", the following fields are required:
+  - explanation: a string representing an explanation of the given concept
+  - exampleProblem: a JSON object representing an example problem, with the same fields as a "problem"
+  - exampleExplanation: a string representing the explanation to solving the example problem
+
+  When given a prompt, you must initially only generate an explanation using the format for an "explanation".
+  However, if previous context is provided, you must use it to generate a problem with the format for a "problem".
+`;
+
 let userRequest; //from search bar
 
 //from API:
-let explanation; 
+let explanation;
 let exampleProblem;
+let exampleExplanation;
 let practiceProblem;
-  let question;
-  let answer; //correct answer
-  let radioA;let radioB;let radioC;let radioD; //four fake answers
-  let correctID;
+let question;
+let answer; //correct answer
+let radioA;
+let radioB;
+let radioC;
+let radioD; //four fake answers
+let correctID;
 
 //submitButton onclick function, populates userRequest
-function search(){
-  userRequest = document.getElementById("input").value; //get userRequest from the search bar
+async function search() {
+  userRequest = document.getElementById("user-search").value; //get userRequest from the search bar
+  print("Generating response, please wait...", "ai-status");
+  await api();
+  publish();
+  print("", "ai-status");
+}
+
+async function ollamaRequest(prompt, previousContext = null) {
+  const GENERATE_URL = `${OLLAMA_HOST}/api/generate`;
+  return fetch(GENERATE_URL, {
+    method: "POST",
+    body: JSON.stringify({
+      model: OLLAMA_MODEL,
+      prompt: prompt,
+      format: "json",
+      stream: false, // TODO: make this true
+      system: OLLAMA_SYSTEM_PROMPT,
+      context: previousContext,
+    }),
+    headers: {
+      "Content-type": "application/json; charset=UTF-8",
+    },
+  })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`HTTP error! Status: ${res.status}`);
+      }
+      return res.json();
+    })
+    .then((data) => {
+      return data;
+    })
+    .catch((error) => {
+      console.error("Unable to fetch data:", error);
+      return null;
+    });
 }
 
 //takes userRequest and transforms it into explanation, exampleProblem, and practiceProblem
-function api(){}
+async function api() {
+  var data = await ollamaRequest(userRequest);
+  console.log(data);
+  var response = data.response;
+  var responseJSON;
+  try {
+    responseJSON = JSON.parse(response);
+  } catch (e) {
+    console.error("AI did not provide a valid JSON response:", response);
+    return;
+  }
+
+  // TODO: maybe call elsewhere?
+  validateExplanation(responseJSON);
+  explanation = responseJSON.explanation;
+  exampleProblem = responseJSON.exampleProblem;
+  exampleExplanation = responseJSON.exampleExplanation;
+
+  return data.context;
+}
 
 //I'm lazy this is my easy method
-function print(content, id){
-  document.getElementById(id).innerHTML = content.toString();
+function print(content, id) {
+  document.getElementById(id).innerHTML = content
+    .toString()
+    .replace(/\n/g, "<br />"); // HACK: replace newlines with HTML line breaks
+}
+
+// validates correct syntax for explanation
+function validateExplanation(explanationJSON) {
+  try {
+    if (
+      typeof explanationJSON.explanation != "string" ||
+      validateProblem(explanationJSON.exampleProblem) ||
+      typeof explanationJSON.exampleExplanation != "string"
+    ) {
+      return false;
+    }
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+// validates correct syntax for explanation
+function validateProblem(problemJSON) {
+  try {
+    if (
+      typeof problemJSON.question != "string" ||
+      typeof problemJSON.answer != "number" ||
+      typeof problemJSON.choices != "object" ||
+      problemJSON.choices.length != 4 ||
+      problemJSON.choices.some((choice) => typeof choice != "string")
+    ) {
+      return false;
+    }
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 //transforms the text from practiceProblem into the question question and false answers radioA/B/C/D and correct answer answer
-function getProblem(){
+function getProblem() {
   //depends on how the API works
 }
 
 //function that throws the data into HTML
-function publish(){
-  print(explanation, "explain");
-  print(exampleProblem, "example");
+function publish() {
+  print(explanation, "explanation");
+  //print(exampleProblem, "exampleProblem");
+  print(exampleExplanation, "exampleExplanation");
+
+  print(exampleProblem.question, "exampleQuestion");
+  exampleProblem.choices.forEach((choice, i) => {
+    const letter = String.fromCharCode(65 + i);
+    print(`${letter}. ${choice}`, `exampleChoice${letter}`);
+    if (i === exampleProblem.answer) {
+      print(`Answer: ${letter}`, "exampleAnswer");
+    }
+  });
+
   //print(practiceProblem, "practice");
 }
 
 //next onclick function
-function nextProblem(){
+function nextProblem() {
   getProblem();
   print(question, "question");
   x = Math.floor(4 * Math.random());
-  if(x == 0){radioA = answer;correctID = "A";}else if(x == 1){radioB = answer;correctID = "B";}else if(x == 2){radioC = answer;correctID = "C";}else{radioD = answer;correctID = "D";} //shuffle where correct answer is //MAKE SURE LINES UP WITH HTML
-  print(radioA, "radioA");print(radioB, "radioB");print(radioC, "radioC");print(radioD, "radioD");
+  if (x == 0) {
+    radioA = answer;
+    correctID = "A";
+  } else if (x == 1) {
+    radioB = answer;
+    correctID = "B";
+  } else if (x == 2) {
+    radioC = answer;
+    correctID = "C";
+  } else {
+    radioD = answer;
+    correctID = "D";
+  } //shuffle where correct answer is //MAKE SURE LINES UP WITH HTML
+  print(radioA, "radioA");
+  print(radioB, "radioB");
+  print(radioC, "radioC");
+  print(radioD, "radioD");
 }
 
 //practiceSubmit submit function
-function checkAnswer((){
-  if(document.getElementByID(correctID).checked == true){window.alert("Correct! :D");}else {window.alert("Try again...")}; //result screen (change later?)
+function checkAnswer() {
+  if (document.getElementByID(correctID).checked == true) {
+    window.alert("Correct! :D");
+  } else {
+    window.alert("Try again...");
+  } //result screen (change later?)
 }


### PR DESCRIPTION
example image here, currently generates an explanation and example problem for a given topic in the text input field:

![image](https://github.com/user-attachments/assets/17e6974b-b3d3-4a41-9f61-c24400471066)

currently set up to request a running ollama instance on `127.0.0.1:11434` with the `llama3:latest` model installed, though configurable with the config files at the top of the `serviceScript.js` file